### PR TITLE
killed right-margin on Top Traded Crypto's tooltip, because it was me…

### DIFF
--- a/app/assets/stylesheets/pages/_dashboard.scss
+++ b/app/assets/stylesheets/pages/_dashboard.scss
@@ -537,7 +537,7 @@ a:link {
   font-size: 15px;
   color: $gray;
   margin-left: 5px;
-  margin-right: 1px;
+  margin-right: 0px;
 }
 
 .tooltip-top {


### PR DESCRIPTION
…ssing the title text in some resolutions